### PR TITLE
Add GitHub Actions workflow to run pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
       matrix:  # https://github.com/actions/python-versions/releases
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "pypy-3.11"]
+        exclude:
+          - os: windows-latest
+            python-version: "pypy-3.11"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Set up CI workflow to run pytest on multiple Python versions on Linux, macOS, and Windows.

Test results: https://github.com/cclauss/madoka-python/actions